### PR TITLE
Added troubleshooting section to the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # config_files
 
-You'll need: 
+You'll need:
 - [ZSH](https://www.zsh.org)
 - [Tmux](https://github.com/tmux/tmux/wiki)
 - [NeoVim](https://neovim.io/)
@@ -13,7 +13,7 @@ Then install vim-plug for neovim:
 https://github.com/junegunn/vim-plug
 
 
-The install the extensions/themes: 
+The install the extensions/themes:
 
 https://github.com/gpakosz/.tmux
 
@@ -35,3 +35,72 @@ $ ln -s ~/config_files/oxide.zsh-theme ~/.oh-my-zsh/themes/oxide.zsh-theme
 If any of them fail, remove the existing file and try again.
 
 If the project is in another folder, adjust the paths accordingly.
+
+
+# Troubleshooting
+
+## Vim Plugins
+### neoclide/coc.nvim
+
+If you have the following error:
+
+```bash
+ [coc.nvim] javascript file not found, please compile the code or use release branch.
+```
+
+Here is the solution:
+
+* Install `nodejs` >= 8.10.0
+* Install `yarn`
+* Inside neovim, type the command:
+
+ ```
+ :call coc#util#install()
+ ```
+* Restart neovim
+* Inside neovim, run:
+
+```
+:PlugInstall
+```
+
+### TaDaa/vimade
+If you have one of the following errors:
+
+```bash
+Error detected while processing function vimade#Init[2]..vimade#CreateGlobals:
+:finish used outside of a sourced file
+```
+or
+
+```bash
+Error detected while processing function vimade#Init[2]..vimade#CreateGlobals:
+Undefined variable: g:vimade_py_cmd
+```
+or
+
+```bash
+Error detected while processing function vimade#Init[15]..vimade#CheckWindows:
+Undefined variable: g:vimade_py_cmd
+```
+
+That means you are missing the `pynvim` package for python. Just install it (run on your terminal):
+
+* If you are using python 2:
+
+```bash
+pip2 install pynvim
+```
+
+* If you are using python 3:
+
+```bash
+pip3 install pynvim
+```
+
+* Restart neovim
+* Inside neovim, run:
+
+```
+:PlugInstall
+```


### PR DESCRIPTION
On a new machine where you don't have somethings setup, you might face some problems on neovim plugins.

I created a troubleshooting section on the README file, that includes only problems with neovim plugins so far, but can be expanded to contain more info about other problems later.